### PR TITLE
[JSC][32bit] Enable concurrency

### DIFF
--- a/JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js
+++ b/JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" and $architecture != "x86_64"
+//@ skip if $memoryLimited
 
 let s = `
 for (let i = 0; i < 10000; i++) {

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -2309,6 +2309,7 @@ void AccessCase::generateImpl(AccessGenerationState& state)
                 CCallHelpers::TrustedImm32(numberOfParameters),
                 calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + PayloadOffset));
 
+            // FIXME: in 32bit platforms we spend an extra instruction to move the CellTag on the second storeCell unnecessarily
             jit.storeCell(
                 loadedValueGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -538,6 +538,10 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
 
 SpeculatedType speculationFromStructure(Structure* structure)
 {
+#if USE(JSVALUE32_64)
+    if (!isLiveConcurrently(structure))
+        return SpecNone;
+#endif
     SpeculatedType filteredResult = SpecNone;
     JSType type = structure->typeInfo().type();
     switch (type) {
@@ -631,6 +635,10 @@ SpeculatedType speculationFromCell(JSCell* cell)
         ASSERT_NOT_REACHED();
         return SpecNone;
     }
+#if USE(JSVALUE32_64)
+    if (!isLiveConcurrently(cell))
+        return SpecNone;
+#endif
     if (cell->isString()) {
         JSString* string = jsCast<JSString*>(cell);
         if (const StringImpl* impl = string->tryGetValueImpl()) {

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -50,30 +50,32 @@ void AbstractValue::observeTransitions(const TransitionVector& vector)
 
 void AbstractValue::set(Graph& graph, const FrozenValue& value, StructureClobberState clobberState)
 {
-    if (!!value && value.value().isCell()) {
-        Structure* structure = value.structure();
-        StructureRegistrationResult result;
-        RegisteredStructure registeredStructure = graph.registerStructure(structure, result);
-        if (result == StructureRegisteredAndWatched) {
-            m_structure = registeredStructure;
-            if (clobberState == StructuresAreClobbered) {
-                m_arrayModes = ALL_ARRAY_MODES;
-                m_structure.clobber();
-            } else
-                m_arrayModes = arrayModesFromStructure(structure);
-        } else {
-            m_structure.makeTop();
-            m_arrayModes = ALL_ARRAY_MODES;
-        }
-    } else {
-        m_structure.clear();
-        m_arrayModes = 0;
-    }
-    
     m_type = speculationFromValue(value.value());
-    m_value = value.value();
-    
-    checkConsistency();
+    if (m_type) {
+        if (!!value && value.value().isCell()) {
+            Structure* structure = value.structure();
+            StructureRegistrationResult result;
+            RegisteredStructure registeredStructure = graph.registerStructure(structure, result);
+            if (result == StructureRegisteredAndWatched) {
+                m_structure = registeredStructure;
+                if (clobberState == StructuresAreClobbered) {
+                    m_arrayModes = ALL_ARRAY_MODES;
+                    m_structure.clobber();
+                } else
+                    m_arrayModes = arrayModesFromStructure(structure);
+            } else {
+                m_structure.makeTop();
+                m_arrayModes = ALL_ARRAY_MODES;
+            }
+        } else {
+            m_structure.clear();
+            m_arrayModes = 0;
+        }
+        m_value = value.value();
+        checkConsistency();
+    } else
+        clear();
+
     assertIsRegistered(graph);
 }
 
@@ -85,24 +87,28 @@ void AbstractValue::set(Graph& graph, Structure* structure)
 void AbstractValue::set(Graph& graph, RegisteredStructure structure)
 {
     RELEASE_ASSERT(structure);
-    
-    m_structure = structure;
-    m_arrayModes = arrayModesFromStructure(structure.get());
+
     m_type = speculationFromStructure(structure.get());
-    m_value = JSValue();
-    
-    checkConsistency();
+    if (m_type) {
+        m_structure = structure;
+        m_arrayModes = arrayModesFromStructure(structure.get());
+        m_value = JSValue();
+        checkConsistency();
+    } else
+        clear();
     assertIsRegistered(graph);
 }
 
 void AbstractValue::set(Graph& graph, const RegisteredStructureSet& set)
 {
-    m_structure = set;
-    m_arrayModes = set.arrayModesFromStructures();
     m_type = set.speculationFromStructures();
-    m_value = JSValue();
-    
-    checkConsistency();
+    if (m_type) {
+        m_structure = set;
+        m_arrayModes = set.arrayModesFromStructures();
+        m_value = JSValue();
+        checkConsistency();
+    } else
+        clear();
     assertIsRegistered(graph);
 }
 
@@ -158,6 +164,8 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
         if (m_value) {
             DFG_ASSERT(graph, node, m_value.isAnyInt());
             m_type = int52AwareSpeculationFromValue(m_value);
+            if (m_type == SpecNone)
+                clear();
         }
     } else {
         if (m_type & SpecInt32AsInt52) {
@@ -204,20 +212,27 @@ bool AbstractValue::mergeOSREntryValue(Graph& graph, JSValue value, VariableAcce
             m_structure.clear();
             m_arrayModes = 0;
         }
-        
+
         m_type = speculationFromValue(value);
-        m_value = value;
+        if (m_type)
+            m_value = value;
+        else
+            clear();
     } else {
-        mergeSpeculation(m_type, speculationFromValue(value));
-        if (!!value && value.isCell()) {
-            RegisteredStructure structure = graph.registerStructure(value.asCell()->structure());
-            mergeArrayModes(m_arrayModes, arrayModesFromStructure(structure.get()));
-            m_structure.merge(RegisteredStructureSet(structure));
-        }
-        if (m_value != value)
-            m_value = JSValue();
+        auto type = speculationFromValue(value);
+        if (m_type) {
+            mergeSpeculation(m_type, type);
+            if (!!value && value.isCell()) {
+                RegisteredStructure structure = graph.registerStructure(value.asCell()->structure());
+                mergeArrayModes(m_arrayModes, arrayModesFromStructure(structure.get()));
+                m_structure.merge(RegisteredStructureSet(structure));
+            }
+            if (m_value != value)
+                m_value = JSValue();
+        } else
+            clear();
     }
-    
+
     assertIsRegistered(graph);
 
     fixTypeForRepresentation(graph, resultFor(flushFormat), node);

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -410,6 +410,10 @@ Heap::Heap(VM& vm, HeapType heapType)
 
     Locker locker { *m_threadLock };
     m_thread = adoptRef(new HeapThread(locker, *this));
+
+#if USE(JSVALUE32_64)
+    CellAddressChecker::instance().add(this);
+#endif
 }
 
 #undef INIT_SERVER_ISO_SUBSPACE
@@ -417,6 +421,10 @@ Heap::Heap(VM& vm, HeapType heapType)
 
 Heap::~Heap()
 {
+#if USE(JSVALUE32_64)
+    CellAddressChecker::instance().remove(this);
+#endif
+
     // Scribble m_worldState to make it clear that the heap has already been destroyed if we crash in checkConn
     m_worldState.store(0xbadbeeffu);
 
@@ -3256,5 +3264,44 @@ DEFINE_DYNAMIC_ISO_SUBSPACE_MEMBER_SLOW(moduleProgramExecutableSpace)
 #undef DEFINE_DYNAMIC_ISO_SUBSPACE_MEMBER_SLOW
 
 } // namespace GCClient
+
+#if USE(JSVALUE32_64)
+CellAddressChecker& CellAddressChecker::instance()
+{
+    static CellAddressChecker* manager;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        manager = new CellAddressChecker();
+    });
+    return *manager;
+}
+
+void CellAddressChecker::add(Heap* h)
+{
+    ASSERT(heap == nullptr);
+    heap = h;
+    heap->objectSpace().enablePreciseAllocationTracking();
+}
+
+void CellAddressChecker::remove(Heap* h)
+{
+    ASSERT_UNUSED(h, heap == h);
+    heap = nullptr;
+}
+
+bool CellAddressChecker::isValidCell(JSCell* pointer)
+{
+    ASSERT(heap != nullptr);
+
+    if (PreciseAllocation::isPreciseAllocation(pointer)) {
+        const HashSet<HeapCell*>* preciseAllocationSet = heap->objectSpace().preciseAllocationSet();
+        return preciseAllocationSet->contains(pointer);
+    }
+
+    const HashSet<MarkedBlock*>& blocksSet = heap->objectSpace().blocks().set();
+    MarkedBlock* candidate = MarkedBlock::blockFor(pointer);
+    return blocksSet.contains(candidate);
+}
+#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1191,4 +1191,23 @@ private:
 
 } // namespace GCClient
 
+#if USE(JSVALUE32_64)
+class CellAddressChecker {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CellAddressChecker);
+    CellAddressChecker() = default;
+
+public:
+    static CellAddressChecker& instance();
+
+    void add(Heap*);
+    void remove(Heap*);
+
+    bool isValidCell(JSCell* candidate);
+
+private:
+    Heap* heap { nullptr };
+};
+#endif
+
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -151,8 +151,8 @@ public:
 #endif
     }
 
-    template<typename U>
-    void storeCell(JSValueRegs regs, U address)
+    template<typename T>
+    void storeCell(JSValueRegs regs, T address)
     {
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
@@ -166,12 +166,7 @@ public:
 #if USE(JSVALUE32_64)
     void storeCell(const void* address)
     {
-#if ENABLE(CONCURRENT_JS)
-        if (Options::useConcurrentJIT()) {
-            store32Concurrently(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
-            return;
-        }
-#endif
+        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
         store32(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
     }
 #endif

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -151,6 +151,11 @@ bool JITPlan::reportCompileTimes() const
         || (Options::reportFTLCompileTimes() && isFTL());
 }
 
+inline bool verboseCompilationEnabled(JITCompilationMode mode = JITCompilationMode::DFG)
+{
+    return Options::verboseCompilation() || Options::dumpGraphAtEachPhase() || Options::logCompilationChanges() || (isFTL(mode) && Options::verboseFTLCompilation());
+}
+
 void JITPlan::compileInThread(JITWorklistThread* thread)
 {
     m_thread = thread;
@@ -164,10 +169,8 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
 
     CompilationScope compilationScope;
 
-#if ENABLE(DFG_JIT)
-    if (DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes())
-        dataLog("DFG(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
-#endif // ENABLE(DFG_JIT)
+    if (verboseCompilationEnabled(m_mode) || Options::logPhaseTimes())
+        dataLog(m_mode, "(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
 
     CompilationPath path = compileInThreadImpl();
 

--- a/Source/JavaScriptCore/runtime/JSCell.cpp
+++ b/Source/JavaScriptCore/runtime/JSCell.cpp
@@ -331,4 +331,29 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCras
 }
 #endif // CPU(X86_64)
 
+#if USE(JSVALUE32_64)
+bool isLiveConcurrently(JSCell* cell)
+{
+    if (!isCompilationThread() || !Options::useConcurrentJIT())
+        return true;
+
+    if (!cell)
+        return false;
+
+    {
+        auto& checker = CellAddressChecker::instance();
+        if (!checker.isValidCell(cell))
+            return false;
+    }
+
+    if (cell->isPreciseAllocation())
+        return cell->preciseAllocation().isLive();
+
+    MarkedBlock& markedBlock = cell->markedBlock();
+    if (!markedBlock.handle().isFreeListed())
+        return markedBlock.handle().isLive(cell);
+    return !cell->isZapped();
+}
+#endif
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -127,7 +127,7 @@ public:
 
     // We use this abstraction to make it easier to grep for places where we lock cells.
     // to lock a cell you can just do:
-    // Locker locker { cell->cellLocker() };
+    // Locker locker { cell->cellLock() };
     JSCellLock& cellLock() { return *reinterpret_cast<JSCellLock*>(this); }
     
     JSType type() const;
@@ -299,6 +299,10 @@ inline auto subspaceForConcurrently(VM& vm)
 
 #if CPU(X86_64)
 JS_EXPORT_PRIVATE NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCrash(Heap&, const JSCell*);
+#endif
+
+#if USE(JSVALUE32_64)
+bool isLiveConcurrently(JSCell*);
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -255,7 +255,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, logExecutableAllocation, false, Normal, nullptr) \
     v(Unsigned, maxDFGNodesInBasicBlockForPreciseAnalysis, 20000, Normal, "Disable precise but costly analysis and give conservative results if the number of DFG nodes in a block exceeds this threshold") \
     \
-    v(Bool, useConcurrentJIT, true, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread") \
+    v(Bool, useConcurrentJIT, is64Bit(), Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread") \
     v(Unsigned, numberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfDFGCompilerThreads, computeNumberOfWorkerThreads(3, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfFTLCompilerThreads, computeNumberOfWorkerThreads(MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS, 2) - 1, Normal, nullptr) \

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -677,11 +677,7 @@
 
 #endif /* !defined(ENABLE_DFG_JIT) && ENABLE(JIT) */
 
-/* Concurrent JS only works on 64-bit platforms because it requires that
-   values get stored to atomically. This is trivially true on 64-bit platforms,
-   but not true at all on 32-bit platforms where values are composed of two
-   separate sub-values. */
-#if ENABLE(JIT) && USE(JSVALUE64)
+#if ENABLE(JIT)
 #define ENABLE_CONCURRENT_JS 1
 #endif
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=239821

Reviewed by NOBODY (OOPS!).

This enables concurrent compilation in 32bit systems (disabled by default for now).

This patch adds a CellAddressChecker singleton that works by checking if the MarkedBlock for the cell pointer is part of the MarkedSpace or if the cell pointer is a precise allocation, this prevents us from checking if an invalid cell pointer is alive. Once we are sure that the pointer is indeed the address of a cell, we then check its liveness.

The patch increases JetStream2's core by 10%, compared to the sequential compilation version (tested on ARMv7):

-----------------------------------------------------------------------------------------------------------------------
|          subtest          |    pts      |    pts      |  b / a   | pValue (significance using False Discovery Rate) |
-----------------------------------------------------------------------------------------------------------------------
| 3d-cube-SP                |168.003460   |197.896428   |1.177931  | 0.000000 (significant)                           |
| 3d-raytrace-SP            |125.885263   |142.579454   |1.132614  | 0.000000 (significant)                           |
| Air                       |99.404368    |122.999226   |1.237362  | 0.000000 (significant)                           |
| Babylon                   |145.309347   |214.018907   |1.472850  | 0.000000 (significant)                           |
| Basic                     |153.158175   |179.640718   |1.172910  | 0.000000 (significant)                           |
| Box2D                     |101.180117   |143.276976   |1.416059  | 0.000000 (significant)                           |
| FlightPlanner             |196.794488   |243.650837   |1.238098  | 0.000000 (significant)                           |
| ML                        |22.791899    |24.481748    |1.074143  | 0.000000 (significant)                           |
| UniPoker                  |77.137275    |79.285938    |1.027855  | 0.000000 (significant)                           |
| ai-astar                  |182.780239   |192.567385   |1.053546  | 0.000000 (significant)                           |
| async-fs                  |59.342978    |66.959267    |1.128344  | 0.000000 (significant)                           |
| base64-SP                 |167.225606   |166.802542   |0.997470  | 0.686498                                         |
| cdjs                      |66.631593    |71.385236    |1.071342  | 0.000000 (significant)                           |
| chai-wtb                  |31.810256    |37.836007    |1.189428  | 0.000000 (significant)                           |
| crypto                    |377.627866   |430.428794   |1.139823  | 0.000000 (significant)                           |
| crypto-aes-SP             |167.633223   |184.030500   |1.097816  | 0.000000 (significant)                           |
| crypto-md5-SP             |139.184882   |145.389688   |1.044580  | 0.000000 (significant)                           |
| crypto-sha1-SP            |149.166710   |154.578164   |1.036278  | 0.000000 (significant)                           |
| date-format-tofte-SP      |93.580246    |98.618666    |1.053841  | 0.000000 (significant)                           |
| date-format-xparb-SP      |85.166072    |85.961056    |1.009335  | 0.110983                                         |
| delta-blue                |209.319699   |261.134918   |1.247541  | 0.000000 (significant)                           |
| earley-boyer              |199.174380   |278.115727   |1.396343  | 0.000000 (significant)                           |
| first-inspector-code-load |133.066103   |132.872875   |0.998548  | 0.699516                                         |
| gaussian-blur             |104.991541   |103.204811   |0.982982  | 0.000113 (significant)                           |
| gbemu                     |29.857200    |35.426628    |1.186536  | 0.000000 (significant)                           |
| hash-map                  |129.324986   |129.253819   |0.999450  | 0.883168                                         |
| jshint-wtb                |14.001002    |16.196957    |1.156843  | 0.000000 (significant)                           |
| json-parse-inspector      |88.522108    |98.992214    |1.118277  | 0.000000 (significant)                           |
| json-stringify-inspector  |116.269868   |113.402364   |0.975338  | 0.000454 (significant)                           |
| multi-inspector-code-load |141.882395   |140.619342   |0.991098  | 0.000022 (significant)                           |
| json-stringify-inspector  |116.269868   |113.402364   |0.975338  | 0.000454 (significant)                           |
| multi-inspector-code-load |141.882395   |140.619342   |0.991098  | 0.000022 (significant)                           |
| n-body-SP                 |338.518764   |344.335936   |1.017184  | 0.000000 (significant)                           |
| navier-stokes             |431.763636   |410.351046   |0.950407  | 0.000000 (significant)                           |
| octane-code-load          |513.281303   |514.226398   |1.001841  | 0.721463                                         |
| pdfjs                     |55.440344    |63.234387    |1.140584  | 0.000000 (significant)                           |
| prepack-wtb               |13.652194    |18.923115    |1.386086  | 0.000000 (significant)                           |
| raytrace                  |190.641417   |224.514530   |1.177680  | 0.000000 (significant)                           |
| regex-dna-SP              |211.065997   |213.340272   |1.010775  | 0.000757 (significant)                           |
| regexp                    |122.335100   |130.886583   |1.069902  | 0.000000 (significant)                           |
| richards                  |237.696021   |252.108170   |1.060633  | 0.000000 (significant)                           |
| splay                     |114.302415   |136.889106   |1.197605  | 0.000000 (significant)                           |
| stanford-crypto-aes       |111.760524   |112.780801   |1.009129  | 0.000254 (significant)                           |
| stanford-crypto-pbkdf2    |213.502982   |228.299684   |1.069304  | 0.000000 (significant)                           |
| stanford-crypto-sha256    |191.188159   |192.977730   |1.009360  | 0.000345 (significant)                           |
| string-unpack-code-SP     |141.324251   |146.013753   |1.033183  | 0.000000 (significant)                           |
| tagcloud-SP               |120.221802   |123.945633   |1.030975  | 0.000000 (significant)                           |
-----------------------------------------------------------------------------------------------------------------------

a mean = 118.02347
b mean = 130.31223
pValue = 0.0000000000
(Bigger means are better.)
1.104 times better
Results ARE significant

* JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js:
* PerformanceTests/JetStream2/watch-cli.js:
* Source/JavaScriptCore/bytecode/AccessCase.cpp: (JSC::AccessCase::generateImpl):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp: (JSC::speculationFromStructure):
(JSC::speculationFromCell):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h: (JSC::DFG::AbstractInterpreter<AbstractStateType>::executeEffects):
* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp: (JSC::DFG::AbstractValue::set):
(JSC::DFG::AbstractValue::fixTypeForRepresentation): (JSC::DFG::AbstractValue::mergeOSREntryValue):
* Source/JavaScriptCore/heap/Heap.cpp: (JSC::Heap::Heap):
(JSC::Heap::~Heap):
(JSC::CellAddressChecker::instance):
(JSC::CellAddressChecker::add):
(JSC::CellAddressChecker::remove):
(JSC::CellAddressChecker::isValidCell):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h: (JSC::AssemblyHelpers::storeCell):
* Source/JavaScriptCore/jit/JITPlan.cpp: (JSC::verboseCompilationEnabled):
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/runtime/JSCell.cpp: (JSC::isLiveConcurrently):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/PlatformEnable.h:

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
